### PR TITLE
Disable middleware in cli mode

### DIFF
--- a/src/Error/Middleware/WhoopsHandlerMiddleware.php
+++ b/src/Error/Middleware/WhoopsHandlerMiddleware.php
@@ -24,7 +24,7 @@ class WhoopsHandlerMiddleware extends ErrorHandlerMiddleware {
 	 * @return \Psr\Http\Message\ResponseInterface A response
 	 */
 	public function handleException($exception, $request, $response) {
-		if (!Configure::read('debug')) {
+		if (!Configure::read('debug') || PHP_SAPI == 'cli') {
 			return parent::handleException($exception, $request, $response);
 		}
 


### PR DESCRIPTION
I was experiencing weird integration test results due to the fact that the middleware was also executing in these scenarios. Adding a cli check ensures we fall back to the default behaviour.