### PR TITLE
Add data tables for Cake Exception and Request

### DIFF
--- a/src/Error/WhoopsHandler.php
+++ b/src/Error/WhoopsHandler.php
@@ -3,7 +3,10 @@
 namespace CakephpWhoops\Error;
 
 use Cake\Core\Configure;
+use Cake\Core\Exception\Exception as CakeException;
 use Cake\Error\ErrorHandler;
+use Cake\Http\ServerRequest;
+use Cake\Routing\Router;
 
 class WhoopsHandler extends ErrorHandler {
 
@@ -35,8 +38,21 @@ class WhoopsHandler extends ErrorHandler {
 			return;
 		}
 
+		$handler = $this->getHandler();
+
+		// Include all attributes defined in Cake Exception as a data table
+		if ($exception instanceof CakeException) {
+            $handler->addDataTable('Cake Exception', $exception->getAttributes());
+        }
+
+        // Include all request parameters as a data table
+        $request = Router::getRequest(true);
+        if ($request instanceof ServerRequest) {
+        	$handler->addDataTable('Cake Request', $request->params);
+        }
+
 		$whoops = $this->getWhoopsInstance();
-		$whoops->pushHandler($this->getHandler());
+		$whoops->pushHandler($handler);
 		$whoops->handleException($exception);
 	}
 


### PR DESCRIPTION
This PR extends the data tables provided by Whoops and adds two new data tables which are CakePHP specific. In particular:

* The 'Cake Exception' data table includes all attributes that have been defined for the raised CakePHP Exception. For instance, for Exception `MissingControllerException` it  displays whether a plugin was matched or not. 
* The 'Cake Request' data table includes all the parameters that have been defined for the CakePHP Request. For instance, it displays the matched plugin, controller, action along with the corresponding route.

Attaching a screenshot for your reference.

![cake-exception-request](https://user-images.githubusercontent.com/586121/45012948-0e4b6980-b022-11e8-9564-87cfe14789cb.png)