### PR TITLE
Don't return HTML errors for JSON requests

### DIFF
--- a/src/Error/Middleware/WhoopsHandlerMiddleware.php
+++ b/src/Error/Middleware/WhoopsHandlerMiddleware.php
@@ -24,7 +24,7 @@ class WhoopsHandlerMiddleware extends ErrorHandlerMiddleware {
 	 * @return \Psr\Http\Message\ResponseInterface A response
 	 */
 	public function handleException($exception, $request, $response) {
-		if (!Configure::read('debug') || PHP_SAPI == 'cli') {
+		if (!Configure::read('debug') || PHP_SAPI == 'cli' || $request->is('json')) {
 			return parent::handleException($exception, $request, $response);
 		}
 


### PR DESCRIPTION
When a request is for `application/json` it's errors should be also.