### PR TITLE
Use ServerRequest::getAttributes instead of deprecated $request->params

### DIFF
--- a/src/Error/WhoopsHandler.php
+++ b/src/Error/WhoopsHandler.php
@@ -48,7 +48,7 @@ class WhoopsHandler extends ErrorHandler {
 		// Include all request parameters as a data table
 		$request = Router::getRequest(true);
 		if ($request instanceof ServerRequest) {
-			$handler->addDataTable('Cake Request', $request->params);
+			$handler->addDataTable('Cake Request', $request->getAttributes());
 		}
 
 		$whoops = $this->getWhoopsInstance();


### PR DESCRIPTION
Avoids breaking with E_USER_DEPRECATED and provides more info for the request.