### PR TITLE
Correcting Middleware use documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ with the Whoops handler:
 When using new Application.php and Middleware approach, you also need to adjust that:
 ```php
 // Replace ErrorHandlerMiddleware with
- ->add(new \CakephpWhoops\Error\Middleware\WhoopsHandlerMiddleware())
+ ->add(new \CakephpWhoops\Error\Middleware\WhoopsHandlerMiddleware(Configure::read('Error')))
 ```
 
 ### Debug Mode


### PR DESCRIPTION
We should pass the `Configure::read('Error')` to the WhoopsMiddleware construct so the Error options are present for the parent ErrorHandlerMiddleware class